### PR TITLE
remove NewLevelDB()

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -24,19 +24,19 @@ type HandlerOptions struct {
 
 func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 	if options.AccountKeeper == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "account keeper is required for AnteHandler")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "account keeper is required for AnteHandler") //nolint:staticcheck // ignore SA1019 // TODO: migrate to cosmossdk.io/errors
 	}
 	if options.BankKeeper == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "bank keeper is required for AnteHandler")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "bank keeper is required for AnteHandler") //nolint:staticcheck // ignore SA1019 // TODO: migrate to cosmossdk.io/errors
 	}
 	if options.SignModeHandler == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "sign mode handler is required for ante builder")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "sign mode handler is required for ante builder") //nolint:staticcheck // ignore SA1019 // TODO: migrate to cosmossdk.io/errors
 	}
 	if options.WasmConfig == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "wasm config is required for ante builder")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "wasm config is required for ante builder") //nolint:staticcheck // ignore SA1019 // TODO: migrate to cosmossdk.io/errors
 	}
 	if options.TXCounterStoreKey == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "tx counter key is required for ante builder")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "tx counter key is required for ante builder") //nolint:staticcheck // ignore SA1019 // TODO: migrate to cosmossdk.io/errors
 	}
 
 	sigGasConsumer := options.SigGasConsumer

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -480,7 +480,7 @@ func NewPubKeyFromHex(pk string) (res cryptotypes.PubKey) {
 		panic(err)
 	}
 	if len(pkBytes) != ed25519.PubKeySize {
-		panic(errors.Wrap(errors.ErrInvalidPubKey, "invalid pubkey size"))
+		panic(errors.Wrap(errors.ErrInvalidPubKey, "invalid pubkey size")) //nolint:staticcheck // ignore SA1019 // TODO: migrate to cosmossdk.io/errors
 	}
 	return &ed25519.PubKey{Key: pkBytes}
 }

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -62,7 +62,7 @@ var DefaultConsensusParams = &abci.ConsensusParams{
 func setup(t testing.TB, withGenesis bool, invCheckPeriod uint, opts ...wasm.Option) (*MigalooApp, GenesisState) {
 	nodeHome := t.TempDir()
 	snapshotDir := filepath.Join(nodeHome, "data", "snapshots")
-	snapshotDB, err := sdk.NewLevelDB("metadata", snapshotDir) //nolint:staticcheck
+	snapshotDB, err := dbm.NewDB("metadata", dbm.MemDBBackend, snapshotDir) //nolint:staticcheck
 	require.NoError(t, err)
 	snapshotStore, err := snapshots.NewStore(snapshotDB, snapshotDir)
 	require.NoError(t, err)

--- a/cmd/migalood/root.go
+++ b/cmd/migalood/root.go
@@ -205,7 +205,7 @@ func (ac appCreator) newApp(
 	}
 
 	snapshotDir := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data", "snapshots")
-	snapshotDB, err := sdk.NewLevelDB("metadata", snapshotDir) //nolint:staticcheck
+	snapshotDB, err := dbm.NewDB("metadata", server.GetAppDBBackend(appOpts), snapshotDir) //nolint:staticcheck
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
sdk.NewLevelDB() no longer used:
https://github.com/cosmos/cosmos-sdk/pull/13380
We should use dbm.NewDB() 

