### PR TITLE
fix: remove redundant init genesis call

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -803,7 +803,6 @@ func NewMigalooApp(
 		tokenfactorytypes.ModuleName,
 		// wasm after ibc transfer
 		wasm.ModuleName,
-		routertypes.ModuleName,
 		alliancemoduletypes.ModuleName,
 	)
 


### PR DESCRIPTION
## Description and Motivation

So in app.go `SetOrderInitGenesis`, we have two `routertypes.ModuleName` 
This PR removes one redundant `routertypes.ModuleName` 

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-chain/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [ ] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-chain/blob/main/docs/CONTRIBUTING.md).
- [ ] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly `golangci-lint run ./... --fix`.
