### PR TITLE
Fix Github action "Push Docker Images"

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -61,6 +61,6 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/White-Whale-Defi-Platform/migaloo-chain:${{ env.MAJOR_VERSION }}
-            ghcr.io/White-Whale-Defi-Platform/migaloo-chain:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}
-            ghcr.io/White-Whale-Defi-Platform/migaloo-chain:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
+            ghcr.io/white-whale-defi-platform/migaloo-chain:${{ env.MAJOR_VERSION }}
+            ghcr.io/white-whale-defi-platform/migaloo-chain:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}
+            ghcr.io/white-whale-defi-platform/migaloo-chain:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}


### PR DESCRIPTION

## Description and Motivation

Image name should be lowercase.

The last build has his error:
```
buildx failed with: ERROR: invalid tag "ghcr.io/White-Whale-Defi-Platform/migaloo-chain:2": repository name must be lowercase
```

## Related Issues

```
buildx failed with: ERROR: invalid tag "ghcr.io/White-Whale-Defi-Platform/migaloo-chain:2": repository name must be lowercase
```
https://github.com/White-Whale-Defi-Platform/migaloo-chain/actions/workflows/push-docker-images.yml

---
## Checklist:

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-chain/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `golangci-lint run ./... --fix`.
