### PR TITLE
retract and use module version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,6 @@ jobs:
   releases-matrix:
     name: Release Go Binary
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux, darwin]
-        goarch: [amd64, arm64]
     steps:
     - uses: actions/checkout@v3   
     - uses: actions/setup-go@v4

--- a/app/app.go
+++ b/app/app.go
@@ -131,14 +131,14 @@ import (
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmclient "github.com/CosmWasm/wasmd/x/wasm/client"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-	wasmappparams "github.com/White-Whale-Defi-Platform/migaloo-chain/app/params"
+	wasmappparams "github.com/White-Whale-Defi-Platform/migaloo-chain/v2/app/params"
 
 	// unnamed import of statik for swagger UI support
 	_ "github.com/cosmos/cosmos-sdk/client/docs/statik"
 
 	// Upgrade Handler
-	upgrades "github.com/White-Whale-Defi-Platform/migaloo-chain/app/upgrades"
-	v2 "github.com/White-Whale-Defi-Platform/migaloo-chain/app/upgrades/v2"
+	upgrades "github.com/White-Whale-Defi-Platform/migaloo-chain/v2/app/upgrades"
+	v2 "github.com/White-Whale-Defi-Platform/migaloo-chain/v2/app/upgrades/v2"
 )
 
 const (

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -3,7 +3,7 @@ package app
 import (
 	"github.com/cosmos/cosmos-sdk/std"
 
-	"github.com/White-Whale-Defi-Platform/migaloo-chain/app/params"
+	"github.com/White-Whale-Defi-Platform/migaloo-chain/v2/app/params"
 )
 
 // MakeEncodingConfig creates a new EncodingConfig with all modules registered

--- a/app/test_access.go
+++ b/app/test_access.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 
-	"github.com/White-Whale-Defi-Platform/migaloo-chain/app/params"
+	"github.com/White-Whale-Defi-Platform/migaloo-chain/v2/app/params"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"

--- a/app/upgrades/v2/constants.go
+++ b/app/upgrades/v2/constants.go
@@ -1,7 +1,7 @@
 package v2
 
 import (
-	"github.com/White-Whale-Defi-Platform/migaloo-chain/app/upgrades"
+	"github.com/White-Whale-Defi-Platform/migaloo-chain/v2/app/upgrades"
 	store "github.com/cosmos/cosmos-sdk/store/types"
 	alliancetypes "github.com/terra-money/alliance/x/alliance/types"
 )

--- a/cmd/migalood/cmd/cmd_test.go
+++ b/cmd/migalood/cmd/cmd_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/White-Whale-Defi-Platform/migaloo-chain/app"
-	"github.com/White-Whale-Defi-Platform/migaloo-chain/cmd/migalood/cmd"
+	"github.com/White-Whale-Defi-Platform/migaloo-chain/v2/app"
+	"github.com/White-Whale-Defi-Platform/migaloo-chain/v2/cmd/migalood/cmd"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 	"github.com/cosmos/cosmos-sdk/simapp"

--- a/cmd/migalood/cmd/root.go
+++ b/cmd/migalood/cmd/root.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-	"github.com/White-Whale-Defi-Platform/migaloo-chain/app"
-	"github.com/White-Whale-Defi-Platform/migaloo-chain/app/params"
+	"github.com/White-Whale-Defi-Platform/migaloo-chain/v2/app"
+	"github.com/White-Whale-Defi-Platform/migaloo-chain/v2/app/params"
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 

--- a/cmd/migalood/main.go
+++ b/cmd/migalood/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"os"
 
-	"github.com/White-Whale-Defi-Platform/migaloo-chain/app"
-	"github.com/White-Whale-Defi-Platform/migaloo-chain/cmd/migalood/cmd"
+	"github.com/White-Whale-Defi-Platform/migaloo-chain/v2/app"
+	"github.com/White-Whale-Defi-Platform/migaloo-chain/v2/cmd/migalood/cmd"
 	"github.com/cosmos/cosmos-sdk/server"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/White-Whale-Defi-Platform/migaloo-chain
+module github.com/White-Whale-Defi-Platform/migaloo-chain/v2
 
 go 1.20
 
@@ -186,3 +186,6 @@ replace (
 	github.com/tendermint/tendermint => github.com/cometbft/cometbft v0.34.29
 
 )
+
+// subject to a bug in the group module and gov module migration
+retract [v2.0.0, v2.1.0]


### PR DESCRIPTION
- don't cross compile
- update module import paths to reflect v2
- retract v2.0.0 - v2.2.0 to ensure they're never used as they 
were at one point tagged
