### PR TITLE
Add ibchooks store key to upgrade

### DIFF
--- a/app/upgrades/v3/constants.go
+++ b/app/upgrades/v3/constants.go
@@ -3,6 +3,7 @@ package v3
 import (
 	"github.com/White-Whale-Defi-Platform/migaloo-chain/v3/app/upgrades"
 	store "github.com/cosmos/cosmos-sdk/store/types"
+	ibchookstypes "github.com/terra-money/core/v2/x/ibc-hooks/types"
 )
 
 // UpgradeName defines the on-chain upgrade name for the Migaloo v2 upgrade.
@@ -11,5 +12,7 @@ const UpgradeName = "v2.2.5"
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,
 	CreateUpgradeHandler: CreateUpgradeHandler,
-	StoreUpgrades:        store.StoreUpgrades{},
+	StoreUpgrades: store.StoreUpgrades{
+		Added: []string{ibchookstypes.StoreKey},
+	},
 }


### PR DESCRIPTION
## Description and Motivation

The current upgrade does not contain ibchook storekey in the StoreUpgrades. 
<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-chain/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [ ] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-chain/blob/main/docs/CONTRIBUTING.md).
- [ ] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly `golangci-lint run ./... --fix`.
