### PR TITLE
fix: IBC hooks wrapper

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -546,7 +546,7 @@ func NewMigalooApp(
 	// IBC Fee Module keeper
 	app.IBCFeeKeeper = ibcfeekeeper.NewKeeper(
 		appCodec, keys[ibcfeetypes.StoreKey],
-		app.IBCKeeper.ChannelKeeper, // may be replaced with IBC middleware
+		app.HooksICS4Wrapper,
 		app.IBCKeeper.ChannelKeeper,
 		&app.IBCKeeper.PortKeeper, app.AccountKeeper, app.BankKeeper,
 	)


### PR DESCRIPTION
Seems like HooksICS4Wrapper is not included in the ibc middleware stack. 

⚠️ Please test this feature before mergining ⚠️ 