### PR TITLE
feat: add migrateMultisigVesting

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1149,6 +1149,8 @@ func (app *MigalooApp) setupUpgradeHandlers() {
 			app.ConsensusParamsKeeper,
 			app.ICAControllerKeeper,
 			app.AccountKeeper,
+			*app.StakingKeeper,
+			app.BankKeeper,
 		),
 	)
 

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -1,9 +1,12 @@
 package app
 
 import (
-	"cosmossdk.io/math"
 	"encoding/json"
 	"fmt"
+	"testing"
+	"time"
+
+	"cosmossdk.io/math"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
@@ -13,15 +16,12 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakinghelper "github.com/cosmos/cosmos-sdk/x/staking/testutil"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	"testing"
-	"time"
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	config "github.com/White-Whale-Defi-Platform/migaloo-chain/v4/app/params"
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/log"
-	tdmtypes "github.com/cometbft/cometbft/proto/tendermint/types"
 	tmtypes "github.com/cometbft/cometbft/types"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -56,10 +56,10 @@ type KeeperTestHelper struct {
 	StakingHelper *stakinghelper.Helper
 }
 
-func (s *KeeperTestHelper) Setup(_ *testing.T, chainID string) {
+func (s *KeeperTestHelper) Setup(_ *testing.T) {
 	t := s.T()
 	s.App = SetupApp(t)
-	s.Ctx = s.App.BaseApp.NewContext(false, tdmtypes.Header{Height: 1, ChainID: "test-1", Time: time.Now().UTC()})
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "test-1", Time: time.Now().UTC()})
 	s.QueryHelper = &baseapp.QueryServiceTestHelper{
 		GRPCQueryRouter: s.App.GRPCQueryRouter(),
 		Ctx:             s.Ctx,
@@ -274,7 +274,7 @@ func (s *KeeperTestHelper) Commit() {
 	oldHeight := s.Ctx.BlockHeight()
 	oldHeader := s.Ctx.BlockHeader()
 	s.App.Commit()
-	newHeader := tdmtypes.Header{Height: oldHeight + 1, ChainID: "testing", Time: oldHeader.Time.Add(time.Second)}
+	newHeader := tmproto.Header{Height: oldHeight + 1, ChainID: "testing", Time: oldHeader.Time.Add(time.Second)}
 	s.App.BeginBlock(abci.RequestBeginBlock{Header: newHeader})
 	s.Ctx = s.App.NewContext(false, newHeader)
 }
@@ -358,7 +358,7 @@ func (s *KeeperTestHelper) BeginNewBlockWithProposer(proposer sdk.ValAddress) {
 
 	newBlockTime := s.Ctx.BlockTime().Add(5 * time.Second)
 
-	header := tdmtypes.Header{Height: s.Ctx.BlockHeight() + 1, Time: newBlockTime}
+	header := tmproto.Header{Height: s.Ctx.BlockHeight() + 1, Time: newBlockTime}
 	newCtx := s.Ctx.WithBlockTime(newBlockTime).WithBlockHeight(s.Ctx.BlockHeight() + 1)
 	s.Ctx = newCtx
 	lastCommitInfo := abci.CommitInfo{

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -1,7 +1,18 @@
 package app
 
 import (
+	"cosmossdk.io/math"
 	"encoding/json"
+	"fmt"
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakinghelper "github.com/cosmos/cosmos-sdk/x/staking/testutil"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"testing"
 	"time"
 
@@ -10,8 +21,9 @@ import (
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/log"
-	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	tdmtypes "github.com/cometbft/cometbft/proto/tendermint/types"
 	tmtypes "github.com/cometbft/cometbft/types"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -36,23 +48,26 @@ const (
 type KeeperTestHelper struct {
 	suite.Suite
 
-	App         *MigalooApp
-	Ctx         sdk.Context // ctx is deliver ctx
-	CheckCtx    sdk.Context
-	QueryHelper *baseapp.QueryServiceTestHelper
-	TestAccs    []sdk.AccAddress
+	App           *MigalooApp
+	Ctx           sdk.Context // ctx is deliver ctx
+	CheckCtx      sdk.Context
+	QueryHelper   *baseapp.QueryServiceTestHelper
+	TestAccs      []sdk.AccAddress
+	StakingHelper *stakinghelper.Helper
 }
 
 func (s *KeeperTestHelper) Setup(_ *testing.T, chainID string) {
-	s.App = SetupApp(s.T())
-	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: chainID, Time: time.Now().UTC()})
-	s.CheckCtx = s.App.BaseApp.NewContext(true, tmproto.Header{Height: 1, ChainID: chainID, Time: time.Now().UTC()})
+	t := s.T()
+	s.App = SetupApp(t)
+	s.Ctx = s.App.BaseApp.NewContext(false, tdmtypes.Header{Height: 1, ChainID: "test-1", Time: time.Now().UTC()})
 	s.QueryHelper = &baseapp.QueryServiceTestHelper{
 		GRPCQueryRouter: s.App.GRPCQueryRouter(),
 		Ctx:             s.Ctx,
 	}
+	s.TestAccs = CreateRandomAccounts(3)
 
-	s.TestAccs = s.RandomAccountAddresses(3)
+	s.StakingHelper = stakinghelper.NewHelper(s.Suite.T(), s.Ctx, s.App.StakingKeeper)
+	s.StakingHelper.Denom = "uwhale"
 }
 
 // DefaultConsensusParams defines the default Tendermint consensus params used
@@ -252,4 +267,178 @@ type EmptyBaseAppOptions struct{}
 // Get implements AppOptions
 func (ao EmptyBaseAppOptions) Get(_ string) interface{} {
 	return nil
+}
+
+// CreateTestContext creates a test context.
+func (s *KeeperTestHelper) Commit() {
+	oldHeight := s.Ctx.BlockHeight()
+	oldHeader := s.Ctx.BlockHeader()
+	s.App.Commit()
+	newHeader := tdmtypes.Header{Height: oldHeight + 1, ChainID: "testing", Time: oldHeader.Time.Add(time.Second)}
+	s.App.BeginBlock(abci.RequestBeginBlock{Header: newHeader})
+	s.Ctx = s.App.NewContext(false, newHeader)
+}
+
+// FundModuleAcc funds target modules with specified amount.
+func (s *KeeperTestHelper) FundModuleAcc(moduleName string, amounts sdk.Coins) {
+	err := banktestutil.FundModuleAccount(s.App.BankKeeper, s.Ctx, moduleName, amounts)
+	s.Require().NoError(err)
+}
+
+func (s *KeeperTestHelper) MintCoins(coins sdk.Coins) {
+	err := s.App.BankKeeper.MintCoins(s.Ctx, minttypes.ModuleName, coins)
+	s.Require().NoError(err)
+}
+
+// SetupValidator sets up a validator and returns the ValAddress.
+func (s *KeeperTestHelper) SetupValidator(bondStatus stakingtypes.BondStatus) sdk.ValAddress {
+	valPriv := secp256k1.GenPrivKey()
+	valPub := valPriv.PubKey()
+	valAddr := sdk.ValAddress(valPub.Address())
+	bondDenom := s.App.StakingKeeper.GetParams(s.Ctx).BondDenom
+	selfBond := sdk.NewCoins(sdk.Coin{Amount: sdk.NewInt(100), Denom: bondDenom})
+
+	s.FundAcc(sdk.AccAddress(valAddr), selfBond)
+
+	msg := s.StakingHelper.CreateValidatorMsg(valAddr, valPub, selfBond[0].Amount)
+	res, err := s.StakingHelper.CreateValidatorWithMsg(s.Ctx, msg)
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+
+	val, found := s.App.StakingKeeper.GetValidator(s.Ctx, valAddr)
+	s.Require().True(found)
+
+	val = val.UpdateStatus(bondStatus)
+	s.App.StakingKeeper.SetValidator(s.Ctx, val)
+
+	consAddr, err := val.GetConsAddr()
+	s.Suite.Require().NoError(err)
+
+	signingInfo := slashingtypes.NewValidatorSigningInfo(
+		consAddr,
+		s.Ctx.BlockHeight(),
+		0,
+		time.Unix(0, 0),
+		false,
+		0,
+	)
+	s.App.SlashingKeeper.SetValidatorSigningInfo(s.Ctx, consAddr, signingInfo)
+
+	return valAddr
+}
+
+// BeginNewBlock starts a new block.
+func (s *KeeperTestHelper) BeginNewBlock() {
+	var valAddr []byte
+
+	validators := s.App.StakingKeeper.GetAllValidators(s.Ctx)
+	if len(validators) >= 1 {
+		valAddrFancy, err := validators[0].GetConsAddr()
+		s.Require().NoError(err)
+		valAddr = valAddrFancy.Bytes()
+	} else {
+		valAddrFancy := s.SetupValidator(stakingtypes.Bonded)
+		validator, _ := s.App.StakingKeeper.GetValidator(s.Ctx, valAddrFancy)
+		valAddr2, _ := validator.GetConsAddr()
+		valAddr = valAddr2.Bytes()
+	}
+
+	s.BeginNewBlockWithProposer(valAddr)
+}
+
+// BeginNewBlockWithProposer begins a new block with a proposer.
+func (s *KeeperTestHelper) BeginNewBlockWithProposer(proposer sdk.ValAddress) {
+	validator, found := s.App.StakingKeeper.GetValidator(s.Ctx, proposer)
+	s.Assert().True(found)
+
+	valConsAddr, err := validator.GetConsAddr()
+	s.Require().NoError(err)
+
+	valAddr := valConsAddr.Bytes()
+
+	newBlockTime := s.Ctx.BlockTime().Add(5 * time.Second)
+
+	header := tdmtypes.Header{Height: s.Ctx.BlockHeight() + 1, Time: newBlockTime}
+	newCtx := s.Ctx.WithBlockTime(newBlockTime).WithBlockHeight(s.Ctx.BlockHeight() + 1)
+	s.Ctx = newCtx
+	lastCommitInfo := abci.CommitInfo{
+		Votes: []abci.VoteInfo{{
+			Validator:       abci.Validator{Address: valAddr, Power: 1000},
+			SignedLastBlock: true,
+		}},
+		Round: 0,
+	}
+	reqBeginBlock := abci.RequestBeginBlock{Header: header, LastCommitInfo: lastCommitInfo}
+
+	fmt.Println("beginning block ", s.Ctx.BlockHeight())
+	s.App.BeginBlocker(s.Ctx, reqBeginBlock)
+}
+
+// EndBlock ends the block.
+func (s *KeeperTestHelper) EndBlock() {
+	reqEndBlock := abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}
+	s.App.EndBlocker(s.Ctx, reqEndBlock)
+}
+
+// AllocateRewardsToValidator allocates reward tokens to a distribution module then allocates rewards to the validator address.
+func (s *KeeperTestHelper) AllocateRewardsToValidator(valAddr sdk.ValAddress, rewardAmt math.Int) {
+	validator, found := s.App.StakingKeeper.GetValidator(s.Ctx, valAddr)
+	s.Require().True(found)
+
+	// allocate reward tokens to distribution module
+	coins := sdk.Coins{sdk.NewCoin(config.BaseDenom, rewardAmt)}
+	err := banktestutil.FundModuleAccount(s.App.BankKeeper, s.Ctx, distrtypes.ModuleName, coins)
+	s.Require().NoError(err)
+
+	// allocate rewards to validator
+	s.Ctx = s.Ctx.WithBlockHeight(s.Ctx.BlockHeight() + 1)
+	decTokens := sdk.DecCoins{{Denom: config.BaseDenom, Amount: sdk.NewDec(20000)}}
+	s.App.DistrKeeper.AllocateTokensToValidator(s.Ctx, validator, decTokens)
+}
+
+// BuildTx builds a transaction.
+func (s *KeeperTestHelper) BuildTx(
+	txBuilder client.TxBuilder,
+	msgs []sdk.Msg,
+	sigV2 signing.SignatureV2,
+	memo string, txFee sdk.Coins,
+	gasLimit uint64,
+) authsigning.Tx {
+	err := txBuilder.SetMsgs(msgs[0])
+	s.Require().NoError(err)
+
+	err = txBuilder.SetSignatures(sigV2)
+	s.Require().NoError(err)
+
+	txBuilder.SetMemo(memo)
+	txBuilder.SetFeeAmount(txFee)
+	txBuilder.SetGasLimit(gasLimit)
+
+	return txBuilder.GetTx()
+}
+
+func (s *KeeperTestHelper) ConfirmUpgradeSucceeded(upgradeName string, upgradeHeight int64) {
+	s.Ctx = s.Ctx.WithBlockHeight(upgradeHeight - 1)
+	plan := upgradetypes.Plan{Name: upgradeName, Height: upgradeHeight}
+	err := s.App.UpgradeKeeper.ScheduleUpgrade(s.Ctx, plan)
+	s.Require().NoError(err)
+	_, exists := s.App.UpgradeKeeper.GetUpgradePlan(s.Ctx)
+	s.Require().True(exists)
+
+	s.Ctx = s.Ctx.WithBlockHeight(upgradeHeight)
+	s.Require().NotPanics(func() {
+		beginBlockRequest := abci.RequestBeginBlock{}
+		s.App.BeginBlocker(s.Ctx, beginBlockRequest)
+	})
+}
+
+// CreateRandomAccounts is a function return a list of randomly generated AccAddresses
+func CreateRandomAccounts(numAccts int) []sdk.AccAddress {
+	testAddrs := make([]sdk.AccAddress, numAccts)
+	for i := 0; i < numAccts; i++ {
+		pk := ed25519.GenPrivKey().PubKey()
+		testAddrs[i] = sdk.AccAddress(pk.Address())
+	}
+
+	return testAddrs
 }

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -59,7 +59,7 @@ type KeeperTestHelper struct {
 func (s *KeeperTestHelper) Setup(_ *testing.T) {
 	t := s.T()
 	s.App = SetupApp(t)
-	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "test-1", Time: time.Now().UTC()})
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "", Time: time.Now().UTC()})
 	s.QueryHelper = &baseapp.QueryServiceTestHelper{
 		GRPCQueryRouter: s.App.GRPCQueryRouter(),
 		Ctx:             s.Ctx,

--- a/app/upgrades/v4_1_0/constants.go
+++ b/app/upgrades/v4_1_0/constants.go
@@ -2,4 +2,8 @@ package v4
 
 // UpgradeName defines the on-chain upgrade name for the Migaloo v3.0.2 upgrade.
 // this upgrade includes the fix for pfm
-const UpgradeName = "v4.1.0"
+const (
+	UpgradeName                       = "v4.1.0"
+	NotionalMultisigVestingAccount    = "migaloo1alga5e8vr6ccr9yrg0kgxevpt5xgmgrvqgujs6"
+	NewNotionalMultisigVestingAccount = "migaloo1tx6f2hetpd9uhveja26kr074496hzk2zzqhsh0"
+)

--- a/app/upgrades/v4_1_0/constants.go
+++ b/app/upgrades/v4_1_0/constants.go
@@ -3,7 +3,7 @@ package v4
 // UpgradeName defines the on-chain upgrade name for the Migaloo v3.0.2 upgrade.
 // this upgrade includes the fix for pfm
 const (
-	UpgradeName                       = "v4.1.0"
-	NotionalMultisigVestingAccount    = "migaloo1alga5e8vr6ccr9yrg0kgxevpt5xgmgrvqgujs6"
-	NewNotionalMultisigVestingAccount = "migaloo1tx6f2hetpd9uhveja26kr074496hzk2zzqhsh0"
+	UpgradeName                    = "v4.1.0"
+	NotionalMultisigVestingAccount = "migaloo1alga5e8vr6ccr9yrg0kgxevpt5xgmgrvqgujs6"
+	NewNotionalMultisigAccount     = "migaloo1tx6f2hetpd9uhveja26kr074496hzk2zzqhsh0"
 )

--- a/app/upgrades/v4_1_0/mainnet_account.go
+++ b/app/upgrades/v4_1_0/mainnet_account.go
@@ -2,6 +2,7 @@ package v4
 
 import (
 	"encoding/json"
+
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	bankKeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 
@@ -14,7 +15,8 @@ import (
 
 func CreateMainnetVestingAccount(ctx sdk.Context,
 	bankKeeper bankKeeper.Keeper,
-	accountKeeper authkeeper.AccountKeeper) (*vestingtypes.ContinuousVestingAccount, math.Int) {
+	accountKeeper authkeeper.AccountKeeper,
+) (vestingtypes.ContinuousVestingAccount, math.Int) {
 	str := `{"@type":"/cosmos.vesting.v1beta1.ContinuousVestingAccount","base_vesting_account":{"base_account":{"address":"migaloo1alga5e8vr6ccr9yrg0kgxevpt5xgmgrvqgujs6","pub_key":{"@type":"/cosmos.crypto.multisig.LegacyAminoPubKey","threshold":4,"public_keys":[{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AlnzK22KrkylnvTCvZZc8eZnydtQuzCWLjJJSMFUvVHf"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"Aiw2Ftg+fnoHDU7M3b0VMRsI0qurXlerW0ahtfzSDZA4"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AvEHv+MVYRVau8FbBcJyG0ql85Tbbn7yhSA0VGmAY4ku"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"Az5VHWqi3zMJu1rLGcu2EgNXLLN+al4Dy/lj6UZTzTCl"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"Ai4GlSH3uG+joMnAFbQC3jQeHl9FPvVTlRmwIFt7d7TI"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"A2kAzH2bZr530jmFq/bRFrT2q8SRqdnfIebba+YIBqI1"}]},"account_number":46,"sequence":27},"original_vesting":[{"denom":"uwhale","amount":"22165200000000"}],"delegated_free":[{"denom":"uwhale","amount":"443382497453"}],"delegated_vesting":[{"denom":"uwhale","amount":"22129422502547"}],"end_time":1770994800},"start_time":1676300400}`
 
 	var acc vestingtypes.ContinuousVestingAccount
@@ -31,5 +33,5 @@ func CreateMainnetVestingAccount(ctx sdk.Context,
 	}
 
 	accountKeeper.SetAccount(ctx, &acc)
-	return &acc, vesting
+	return acc, vesting
 }

--- a/app/upgrades/v4_1_0/mainnet_account.go
+++ b/app/upgrades/v4_1_0/mainnet_account.go
@@ -1,0 +1,35 @@
+package v4
+
+import (
+	"encoding/json"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	bankKeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+
+	"cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	banktestutil "github.com/cosmos/cosmos-sdk/x/bank/testutil"
+)
+
+func CreateMainnetVestingAccount(ctx sdk.Context,
+	bankKeeper bankKeeper.Keeper,
+	accountKeeper authkeeper.AccountKeeper) (*vestingtypes.ContinuousVestingAccount, math.Int) {
+	str := `{"@type":"/cosmos.vesting.v1beta1.ContinuousVestingAccount","base_vesting_account":{"base_account":{"address":"migaloo1alga5e8vr6ccr9yrg0kgxevpt5xgmgrvqgujs6","pub_key":{"@type":"/cosmos.crypto.multisig.LegacyAminoPubKey","threshold":4,"public_keys":[{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AlnzK22KrkylnvTCvZZc8eZnydtQuzCWLjJJSMFUvVHf"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"Aiw2Ftg+fnoHDU7M3b0VMRsI0qurXlerW0ahtfzSDZA4"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AvEHv+MVYRVau8FbBcJyG0ql85Tbbn7yhSA0VGmAY4ku"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"Az5VHWqi3zMJu1rLGcu2EgNXLLN+al4Dy/lj6UZTzTCl"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"Ai4GlSH3uG+joMnAFbQC3jQeHl9FPvVTlRmwIFt7d7TI"},{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"A2kAzH2bZr530jmFq/bRFrT2q8SRqdnfIebba+YIBqI1"}]},"account_number":46,"sequence":27},"original_vesting":[{"denom":"uwhale","amount":"22165200000000"}],"delegated_free":[{"denom":"uwhale","amount":"443382497453"}],"delegated_vesting":[{"denom":"uwhale","amount":"22129422502547"}],"end_time":1770994800},"start_time":1676300400}`
+
+	var acc vestingtypes.ContinuousVestingAccount
+	if err := json.Unmarshal([]byte(str), &acc); err != nil {
+		panic(err)
+	}
+
+	vesting := GetVestingCoin(ctx, &acc)
+
+	err := banktestutil.FundAccount(bankKeeper, ctx, acc.BaseAccount.GetAddress(),
+		acc.GetOriginalVesting())
+	if err != nil {
+		panic(err)
+	}
+
+	accountKeeper.SetAccount(ctx, &acc)
+	return &acc, vesting
+}

--- a/app/upgrades/v4_1_0/upgrades.go
+++ b/app/upgrades/v4_1_0/upgrades.go
@@ -70,7 +70,8 @@ func CreateUpgradeHandler(
 func migrateMultisigVesting(ctx sdk.Context,
 	stakingKeeper stakingKeeper.Keeper,
 	bankKeeper bankKeeper.Keeper,
-	accountKeeper authkeeper.AccountKeeper) {
+	accountKeeper authkeeper.AccountKeeper,
+) {
 	currentAddr := sdk.MustAccAddressFromBech32(NotionalMultisigVestingAccount)
 	newAddr := sdk.MustAccAddressFromBech32(NewNotionalMultisigVestingAccount)
 
@@ -88,7 +89,8 @@ func migrateMultisigVesting(ctx sdk.Context,
 
 func processMigrateMultisig(ctx sdk.Context, stakingKeeper stakingKeeper.Keeper,
 	bankKeeper bankKeeper.Keeper, currentAddr, newAddr sdk.AccAddress,
-	oldAcc *vestingtypes.ContinuousVestingAccount) { // nolint:gocritic
+	oldAcc *vestingtypes.ContinuousVestingAccount,
+) {
 	redelegated, err := completeAllRedelegations(ctx, ctx.BlockTime(), stakingKeeper, currentAddr)
 	if err != nil {
 		panic(err)
@@ -102,7 +104,7 @@ func processMigrateMultisig(ctx sdk.Context, stakingKeeper stakingKeeper.Keeper,
 	fmt.Printf("currentAddr Instant Redelegations: %s\n", redelegated)
 	fmt.Printf("currentAddr Instant Unbonding: %s\n", unbonded)
 
-	//delegate vesting coin to validator
+	// delegate vesting coin to validator
 	err = delegateToValidator(ctx, stakingKeeper, currentAddr, oldAcc.GetVestingCoins(ctx.BlockTime())[0].Amount)
 	if err != nil {
 		panic(err)
@@ -121,8 +123,8 @@ func processMigrateMultisig(ctx sdk.Context, stakingKeeper stakingKeeper.Keeper,
 	if err != nil {
 		panic(err)
 	}
-
 }
+
 func GetVestingCoin(ctx sdk.Context, acc *vestingtypes.ContinuousVestingAccount) (unvested math.Int) {
 	vestingCoin := acc.GetVestingCoins(ctx.BlockTime())
 	return vestingCoin[0].Amount
@@ -130,7 +132,8 @@ func GetVestingCoin(ctx sdk.Context, acc *vestingtypes.ContinuousVestingAccount)
 
 func completeAllRedelegations(ctx sdk.Context, now time.Time,
 	stakingKeeper stakingKeeper.Keeper,
-	accAddr sdk.AccAddress) (math.Int, error) {
+	accAddr sdk.AccAddress,
+) (math.Int, error) {
 	redelegatedAmt := math.ZeroInt()
 
 	for _, activeRedelegation := range stakingKeeper.GetRedelegations(ctx, accAddr, 65535) {
@@ -155,7 +158,8 @@ func completeAllRedelegations(ctx sdk.Context, now time.Time,
 
 func unbondAllAndFinish(ctx sdk.Context, now time.Time,
 	stakingKeeper stakingKeeper.Keeper,
-	accAddr sdk.AccAddress) (math.Int, error) {
+	accAddr sdk.AccAddress,
+) (math.Int, error) {
 	unbondedAmt := math.ZeroInt()
 
 	// Unbond all delegations from the account
@@ -196,8 +200,9 @@ func unbondAllAndFinish(ctx sdk.Context, now time.Time,
 // delegate to top 10 validator
 func delegateToValidator(ctx sdk.Context,
 	stakingKeeper stakingKeeper.Keeper,
-	accAddr sdk.AccAddress, totalVestingBalance math.Int) error {
-
+	accAddr sdk.AccAddress,
+	totalVestingBalance math.Int,
+) error {
 	listValidator := stakingKeeper.GetBondedValidatorsByPower(ctx)
 	totalValidatorDelegate := math.Min(10, len(listValidator))
 	balanceDelegate := totalVestingBalance.Quo(totalVestingBalance)

--- a/app/upgrades/v4_1_0/upgrades.go
+++ b/app/upgrades/v4_1_0/upgrades.go
@@ -115,8 +115,6 @@ func processMigrateMultisig(ctx sdk.Context, stakingKeeper stakingKeeper.Keeper,
 	fmt.Println("total balance before migration ", totalBalance)
 	balanceCanSend := totalBalance.Amount.Sub(oldAcc.GetVestingCoins(ctx.BlockTime())[0].Amount)
 
-	// keep 100.000.000 uwhate for tx fee
-	balanceCanSend = balanceCanSend.Sub(math.NewInt(100_000_000))
 	fmt.Printf("total balance send to new multisig addr: %s\n", balanceCanSend)
 	// send vested + reward balance no newAddr
 	err = bankKeeper.SendCoins(ctx, currentAddr, newAddr, sdk.NewCoins(sdk.NewCoin(params.BaseDenom, balanceCanSend)))

--- a/app/upgrades/v4_1_0/upgrades.go
+++ b/app/upgrades/v4_1_0/upgrades.go
@@ -73,7 +73,7 @@ func migrateMultisigVesting(ctx sdk.Context,
 	accountKeeper authkeeper.AccountKeeper,
 ) {
 	currentAddr := sdk.MustAccAddressFromBech32(NotionalMultisigVestingAccount)
-	newAddr := sdk.MustAccAddressFromBech32(NewNotionalMultisigVestingAccount)
+	newAddr := sdk.MustAccAddressFromBech32(NewNotionalMultisigAccount)
 
 	currentAcc := accountKeeper.GetAccount(ctx, currentAddr)
 

--- a/app/upgrades/v4_1_0/upgrades_test.go
+++ b/app/upgrades/v4_1_0/upgrades_test.go
@@ -1,6 +1,7 @@
 package v4_test
 
 import (
+	"cosmossdk.io/math"
 	"fmt"
 	"testing"
 
@@ -78,6 +79,12 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	// check new multisign address balance
 	newBalance := s.App.BankKeeper.GetAllBalances(s.Ctx, sdk.MustAccAddressFromBech32(v4.NewNotionalMultisigAccount))
 	vestedBalance := cVesting.GetVestedCoins(s.Ctx.BlockTime())
-	fmt.Printf("New multisign Upgrade Balance: %s\n", newBalance)
+	fmt.Printf("New multisign Upgrade Balance: %s, vestedBalance %s\n", newBalance, vestedBalance)
 	s.Require().True(newBalance.AmountOf(params.BaseDenom).LTE(vestedBalance.AmountOf(params.BaseDenom)))
+}
+
+func (s *UpgradeTestSuite) TestMath() {
+	s.Require().Equal(math.NewInt(7), math.NewInt(76).Quo(math.NewInt(10)))
+	s.Require().Equal(math.NewInt(7), math.NewInt(79).Quo(math.NewInt(10)))
+	s.Require().Equal(math.NewInt(1), math.NewInt(5).Quo(math.NewInt(3)))
 }

--- a/app/upgrades/v4_1_0/upgrades_test.go
+++ b/app/upgrades/v4_1_0/upgrades_test.go
@@ -1,16 +1,16 @@
 package v4_test
 
 import (
+	"fmt"
+	"github.com/White-Whale-Defi-Platform/migaloo-chain/v4/app/params"
+	v4 "github.com/White-Whale-Defi-Platform/migaloo-chain/v4/app/upgrades/v4_1_0"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"testing"
 
 	apptesting "github.com/White-Whale-Defi-Platform/migaloo-chain/v4/app"
-	abci "github.com/cometbft/cometbft/abci/types"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"github.com/stretchr/testify/suite"
-)
-
-const (
-	v4UpgradeHeight = int64(10)
 )
 
 type UpgradeTestSuite struct {
@@ -21,25 +21,63 @@ func TestUpgradeTestSuite(t *testing.T) {
 	suite.Run(t, new(UpgradeTestSuite))
 }
 
-func (suite *UpgradeTestSuite) TestUpgrade() {
-	suite.Setup(suite.T(), apptesting.SimAppChainID)
-	dummyUpgrade(suite)
-	feeBurnParam := suite.App.FeeBurnKeeper.GetParams(suite.Ctx)
-	suite.Require().Equal("0", feeBurnParam.GetTxFeeBurnPercent())
-}
+// Ensures the test does not error out.
+func (s *UpgradeTestSuite) TestUpgrade() {
+	s.Setup(s.T(), apptesting.SimAppChainID)
+	// == CREATE MOCK VESTING ACCOUNT ==
+	cVesting, unvested := v4.CreateMainnetVestingAccount(s.Ctx, s.App.BankKeeper, s.App.AccountKeeper)
+	vestingAddr := cVesting.GetAddress()
+	fmt.Printf("VestingAddr unvested: %+v\n", unvested)
 
-func dummyUpgrade(s *UpgradeTestSuite) {
-	s.Ctx = s.Ctx.WithBlockHeight(v4UpgradeHeight - 1)
-	plan := upgradetypes.Plan{Name: "v4.1.0", Height: v4UpgradeHeight}
-	err := s.App.UpgradeKeeper.ScheduleUpgrade(s.Ctx, plan)
+	accVestingBalance := s.App.BankKeeper.GetAllBalances(s.Ctx, vestingAddr)
+	fmt.Printf("Acc vesting bal: %s\n", accVestingBalance)
+
+	// create many validators to confirm the unbonding code works
+	newVal1 := s.SetupValidator(stakingtypes.Bonded)
+	newVal2 := s.SetupValidator(stakingtypes.Bonded)
+	newVal3 := s.SetupValidator(stakingtypes.Bonded)
+
+	// Delegate tokens of the vesting multisig account
+	s.StakingHelper.Delegate(vestingAddr, newVal1, sdk.NewInt(100))
+	s.StakingHelper.Delegate(vestingAddr, newVal2, sdk.NewInt(200))
+	s.StakingHelper.Delegate(vestingAddr, newVal3, sdk.NewInt(300))
+
+	// Undelegate part of the tokens from val2 (test instant unbonding on undelegation started before upgrade)
+	s.StakingHelper.Undelegate(vestingAddr, newVal3, sdk.NewInt(10), true)
+
+	// Redelegate part of the tokens from val2 -> val3 (test instant unbonding on redelegations started before upgrade)
+	_, err := s.App.StakingKeeper.BeginRedelegation(s.Ctx, vestingAddr, newVal2, newVal3, sdk.NewDec(1))
 	s.Require().NoError(err)
-	_, exists := s.App.UpgradeKeeper.GetUpgradePlan(s.Ctx)
-	s.Require().True(exists)
 
-	s.Ctx = s.Ctx.WithBlockHeight(v4UpgradeHeight)
+	// Confirm delegated to 3 validators
+	s.Require().Equal(3, len(s.App.StakingKeeper.GetAllDelegatorDelegations(s.Ctx, vestingAddr)))
 
-	s.Require().NotPanics(func() {
-		beginBlockRequest := abci.RequestBeginBlock{}
-		s.App.BeginBlocker(s.Ctx, beginBlockRequest)
-	})
+	// == UPGRADE ==
+	upgradeHeight := int64(5)
+	s.ConfirmUpgradeSucceeded(v4.UpgradeName, upgradeHeight)
+
+	// == VERIFICATION FEEBURN ==
+	feeBurnParam := s.App.FeeBurnKeeper.GetParams(s.Ctx)
+	s.Require().Equal("0", feeBurnParam.GetTxFeeBurnPercent())
+
+	// VERIFY MULTISIGN MIGRATION
+	accAfter := s.App.AccountKeeper.GetAccount(s.Ctx, vestingAddr)
+	_, ok := accAfter.(*vestingtypes.ContinuousVestingAccount)
+	s.Require().True(ok)
+
+	s.Require().Equal(1, len(s.App.BankKeeper.GetAllBalances(s.Ctx, vestingAddr)))
+	s.Require().Equal(4, len(s.App.StakingKeeper.GetAllDelegatorDelegations(s.Ctx, vestingAddr)))
+	s.Require().Equal(0, len(s.App.StakingKeeper.GetRedelegations(s.Ctx, vestingAddr, 65535)))
+
+	// check old multisign address balance
+	oldMultisigBalance := s.App.BankKeeper.GetAllBalances(s.Ctx, sdk.MustAccAddressFromBech32(v4.NotionalMultisigVestingAccount))
+	fmt.Printf("Old multisign address Upgrade Balance: %s\n", oldMultisigBalance)
+	s.Require().True(oldMultisigBalance.AmountOf(params.BaseDenom).GTE(unvested))
+
+	// check new multisign address balance
+	newBalance := s.App.BankKeeper.GetAllBalances(s.Ctx, sdk.MustAccAddressFromBech32(v4.NewNotionalMultisigVestingAccount))
+	vestedBalance := cVesting.GetVestedCoins(s.Ctx.BlockTime())
+	fmt.Printf("New multisign Upgrade Balance: %s\n", newBalance)
+	s.Require().True(newBalance.AmountOf(params.BaseDenom).LTE(vestedBalance.AmountOf(params.BaseDenom)))
+
 }

--- a/app/upgrades/v4_1_0/upgrades_test.go
+++ b/app/upgrades/v4_1_0/upgrades_test.go
@@ -76,7 +76,7 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	s.Require().True(oldMultisigBalance.AmountOf(params.BaseDenom).GTE(unvested))
 
 	// check new multisign address balance
-	newBalance := s.App.BankKeeper.GetAllBalances(s.Ctx, sdk.MustAccAddressFromBech32(v4.NewNotionalMultisigVestingAccount))
+	newBalance := s.App.BankKeeper.GetAllBalances(s.Ctx, sdk.MustAccAddressFromBech32(v4.NewNotionalMultisigAccount))
 	vestedBalance := cVesting.GetVestedCoins(s.Ctx.BlockTime())
 	fmt.Printf("New multisign Upgrade Balance: %s\n", newBalance)
 	s.Require().True(newBalance.AmountOf(params.BaseDenom).LTE(vestedBalance.AmountOf(params.BaseDenom)))

--- a/app/upgrades/v4_1_0/upgrades_test.go
+++ b/app/upgrades/v4_1_0/upgrades_test.go
@@ -1,9 +1,10 @@
 package v4_test
 
 import (
-	"cosmossdk.io/math"
 	"fmt"
 	"testing"
+
+	"cosmossdk.io/math"
 
 	"github.com/White-Whale-Defi-Platform/migaloo-chain/v4/app/params"
 	v4 "github.com/White-Whale-Defi-Platform/migaloo-chain/v4/app/upgrades/v4_1_0"

--- a/app/upgrades/v4_1_0/upgrades_test.go
+++ b/app/upgrades/v4_1_0/upgrades_test.go
@@ -2,12 +2,13 @@ package v4_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/White-Whale-Defi-Platform/migaloo-chain/v4/app/params"
 	v4 "github.com/White-Whale-Defi-Platform/migaloo-chain/v4/app/upgrades/v4_1_0"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"testing"
 
 	apptesting "github.com/White-Whale-Defi-Platform/migaloo-chain/v4/app"
 	"github.com/stretchr/testify/suite"
@@ -23,7 +24,7 @@ func TestUpgradeTestSuite(t *testing.T) {
 
 // Ensures the test does not error out.
 func (s *UpgradeTestSuite) TestUpgrade() {
-	s.Setup(s.T(), apptesting.SimAppChainID)
+	s.Setup(s.T())
 	// == CREATE MOCK VESTING ACCOUNT ==
 	cVesting, unvested := v4.CreateMainnetVestingAccount(s.Ctx, s.App.BankKeeper, s.App.AccountKeeper)
 	vestingAddr := cVesting.GetAddress()
@@ -79,5 +80,4 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	vestedBalance := cVesting.GetVestedCoins(s.Ctx.BlockTime())
 	fmt.Printf("New multisign Upgrade Balance: %s\n", newBalance)
 	s.Require().True(newBalance.AmountOf(params.BaseDenom).LTE(vestedBalance.AmountOf(params.BaseDenom)))
-
 }

--- a/app/upgrades/v4_1_0/upgrades_test.go
+++ b/app/upgrades/v4_1_0/upgrades_test.go
@@ -74,13 +74,15 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	// check old multisign address balance
 	oldMultisigBalance := s.App.BankKeeper.GetAllBalances(s.Ctx, sdk.MustAccAddressFromBech32(v4.NotionalMultisigVestingAccount))
 	fmt.Printf("Old multisign address Upgrade Balance: %s\n", oldMultisigBalance)
-	s.Require().True(oldMultisigBalance.AmountOf(params.BaseDenom).GTE(unvested))
+	totalDelegateBalance := s.App.StakingKeeper.GetDelegatorBonded(s.Ctx, sdk.MustAccAddressFromBech32(v4.NotionalMultisigVestingAccount))
+	fmt.Printf("old multisign address totalDelegateBalance %v\n", totalDelegateBalance)
+	s.Require().True(totalDelegateBalance.Add(oldMultisigBalance[0].Amount).GTE(unvested))
 
 	// check new multisign address balance
 	newBalance := s.App.BankKeeper.GetAllBalances(s.Ctx, sdk.MustAccAddressFromBech32(v4.NewNotionalMultisigAccount))
 	vestedBalance := cVesting.GetVestedCoins(s.Ctx.BlockTime())
 	fmt.Printf("New multisign Upgrade Balance: %s, vestedBalance %s\n", newBalance, vestedBalance)
-	s.Require().True(newBalance.AmountOf(params.BaseDenom).LTE(vestedBalance.AmountOf(params.BaseDenom)))
+	s.Require().True(vestedBalance.AmountOf(params.BaseDenom).GTE(newBalance.AmountOf(params.BaseDenom)))
 }
 
 func (s *UpgradeTestSuite) TestMath() {

--- a/scripts/run-node.sh
+++ b/scripts/run-node.sh
@@ -82,5 +82,5 @@ $BINARY collect-gentxs --home $HOME_DIR
 
 # Run this to ensure everything worked and that the genesis file is setup correctly
 $BINARY validate-genesis --home $HOME_DIR
-# $BINARY start --home $HOME_DIR
+$BINARY start --home $HOME_DIR
 

--- a/x/feeburn/ante/utils_test.go
+++ b/x/feeburn/ante/utils_test.go
@@ -34,7 +34,7 @@ type AnteTestSuite struct {
 
 // SetupTest setups a new test, with new app, context, and anteHandler.
 func (suite *AnteTestSuite) SetupTest() {
-	suite.Setup(suite.T(), apptesting.SimAppChainID)
+	suite.Setup(suite.T())
 
 	// Set up TxConfig.
 	encodingConfig := simapp.MakeTestEncodingConfig()

--- a/x/feeburn/keeper/keeper_test.go
+++ b/x/feeburn/keeper/keeper_test.go
@@ -31,7 +31,7 @@ type KeeperTestSuite struct {
 
 // SetupTest setups a new test, with new app, context, and anteHandler.
 func (suite *KeeperTestSuite) SetupTest() {
-	suite.Setup(suite.T(), apptesting.SimAppChainID)
+	suite.Setup(suite.T())
 
 	// Set up TxConfig.
 	encodingConfig := config.MakeEncodingConfig()


### PR DESCRIPTION
Moves the vested and reward token from the ContinuousVestingAccount of Notional Team to new multisig account.
- Retrieves the old multisig vesting account
- Instantly finish all redelegations, then unbond all tokens.
- Transfer all tokens vested and reward tokens to the new multisig account (including the previously held balance)
- Delegates the unvested coins from Old Multisign Vesting Account to the top 10 validators

Migration from account migaloo1alga5e8vr6ccr9yrg0kgxevpt5xgmgrvqgujs6. to migaloo1tx6f2hetpd9uhveja26kr074496hzk2zzqhsh0